### PR TITLE
Return a non-zero exit-code on error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::process::exit;
 
 const SESSION_COOKIE_FILE: &str = ".adventofcode.session";
 
-fn main() {
+fn main() -> Result<(), String> {
     let args = parse_args();
     let year = if args.is_present("year") {
         Some(value_t_or_exit!(args, "year", PuzzleYear))
@@ -26,7 +26,7 @@ fn main() {
 
     let session_cookie = read_session_cookie(args.value_of("session"));
 
-    let result = match args.value_of("command").unwrap() {
+    match args.value_of("command").unwrap() {
         cmd if cmd == "download" || cmd == "d" => {
             let filename = args.value_of("file").unwrap();
             download_input(&session_cookie, year, day, filename)
@@ -40,10 +40,6 @@ fn main() {
             read_puzzle(&session_cookie, year, day)
         }
         _ => unreachable!(),
-    };
-
-    if let Err(err) = result {
-        eprintln!("Error: {}", err);
     }
 }
 


### PR DESCRIPTION
First - thanks for an awesome CLI!!! Here's a small fix for an issue I ran into when gearing up for this year :)

This is a common (miss)-behavior of a lot of CLI utilities that rust
makes very easy to fix - by simply returning a Result type from the main()
function (which we already have). This will default to 1 for all
failures.

This is useful for scripting downloads and submissions, but is also
generally the right behavior of a unix utility on error.

We also remove logging the error as this is the default behavior when
returning result from main anyway.

Tested locally with

  $ ./target/debug/aoc d --year 2021 --day 20  # not out yet when tested
  Loaded session cookie from "~/.adventofcode.session".
  Error: "Puzzle 20 of 2021 is still locked."
  $ echo $?
  1