### PR TITLE
Allow user to specify width of output

### DIFF
--- a/src/aoc.rs
+++ b/src/aoc.rs
@@ -9,6 +9,7 @@ use std::io::Write;
 
 pub type PuzzleYear = i32;
 pub type PuzzleDay = u32;
+pub type ColumnWidth = usize;
 
 const FIRST_EVENT_YEAR: PuzzleYear = 2015;
 const DECEMBER: u32 = 12;
@@ -22,6 +23,10 @@ pub fn is_valid_year(year: PuzzleYear) -> bool {
 
 pub fn is_valid_day(day: PuzzleDay) -> bool {
     day >= FIRST_PUZZLE_DAY && day <= LAST_PUZZLE_DAY
+}
+
+pub fn is_valid_width(width: ColumnWidth) -> bool {
+    width > 0
 }
 
 pub fn latest_event_year() -> PuzzleYear {
@@ -135,6 +140,7 @@ pub fn submit_answer(
     opt_day: Option<PuzzleDay>,
     part: &str,
     answer: &str,
+    opt_width: Option<ColumnWidth>,
 ) -> Result<(), String> {
     let (year, day) = puzzle_day_year(opt_year, opt_day)?;
 
@@ -160,8 +166,10 @@ pub fn submit_answer(
         .unwrap()
         .as_str();
 
-    let term_width = term_size::dimensions().map(|(w, _)| w).unwrap_or(80);
-    println!("\n{}", from_read(result.as_bytes(), term_width));
+    let output_width = opt_width.unwrap_or_else(|| {
+        term_size::dimensions().map(|(w, _)| w).unwrap_or(80)
+    });
+    println!("\n{}", from_read(result.as_bytes(), output_width));
     Ok(())
 }
 
@@ -169,6 +177,7 @@ pub fn read_puzzle(
     session_cookie: &str,
     opt_year: Option<PuzzleYear>,
     opt_day: Option<PuzzleDay>,
+    opt_width: Option<ColumnWidth>,
 ) -> Result<(), String> {
     let (year, day) = puzzle_day_year(opt_year, opt_day)?;
 
@@ -189,7 +198,9 @@ pub fn read_puzzle(
         .unwrap()
         .as_str();
 
-    let term_width = term_size::dimensions().map(|(w, _)| w).unwrap_or(80);
-    println!("\n{}", from_read(description.as_bytes(), term_width));
+    let output_width = opt_width.unwrap_or_else(|| {
+        term_size::dimensions().map(|(w, _)| w).unwrap_or(80)
+    });
+    println!("\n{}", from_read(description.as_bytes(), output_width));
     Ok(())
 }


### PR DESCRIPTION
First, thanks for aoc-cli. I've been playing around with it in the lead-up to AOC this year and it's great.

This PR adds support for specifying the output width when reading a puzzle. I'm working in a wide terminal but want the output to be substantially narrower than that. I can use a tool like `fold` or `fmt` but neither is ideal. `fold` will cause strange line-wrapping and `fmt` will smush together example input.

I'm not a Rust programmer so made the changes largely by copying code from the existing argument parsing rules and following the suggestions in the compiler errors. So far, so good on my machine. 