### PR TITLE
fix: update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "aoc-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "clap",


### PR DESCRIPTION
The outdated Cargo.lock causes my NixOS package build to break ;) Thanks for this tool, looking forward to using it in December again. Winter is coming!