### PR TITLE
feat: Add private-leaderboard command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "openssl",
  "regex",
  "reqwest",
+ "serde",
  "term_size",
  "thiserror",
 ]
@@ -1360,6 +1361,20 @@ name = "serde"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ html2text = "0.4"
 http = "0.2"
 log = "0.4"
 regex = "1.7"
-reqwest = { version = "0.11", features = ["blocking"] }
+reqwest = { version = "0.11", features = ["blocking", "json"] }
+serde = { version = "1.0", features=["derive"] }
 term_size = "0.3"
 thiserror = "1.0"
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -95,6 +95,10 @@ pub enum Command {
         /// Puzzle answer
         answer: String,
     },
+
+    /// Get private leaderboard results
+    #[command(visible_alias = "pr")]
+    PrivateLeaderboard { leaderboard: String },
 }
 
 fn convert_number<T: FromStr>(s: &str) -> Result<T, String>

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,9 @@ fn run(args: &Args) -> AocResult<()> {
         Some(Command::Submit { part, answer }) => {
             submit(args, &session, width, part, answer)
         }
+        Some(Command::PrivateLeaderboard { leaderboard }) => {
+            show_private_leaderboard_results(args, &session, leaderboard)
+        }
         _ => read(args, &session, width),
     }
 }


### PR DESCRIPTION
Adds a private leaderboard command to print the results of a given private leaderboard. 

Example output is similar to that on the website - but without colors or headers.

```
1       142     ★★★★★★★★★★★                     byarr
2       129     ★★★★★★★★★★★                     Someone else
3       125     ★★★★★★★★★★★                     anonymous user #122345
4       108     ★★★★★★★★★★★                     Bob Jones
5       87      ★★★★★★★★★★★                     Jane Doe
6       83      ★★★★★★★★★★★                     abcdef
7       78      ★★★.★★★★★★★                     anonymous user #12344
8       28      ★★★★★★.....                     Some one
```