### PR TITLE
fix: Proper display of stars for 2022 Day 25

### DIFF
--- a/aoc-client/src/lib.rs
+++ b/aoc-client/src/lib.rs
@@ -384,6 +384,12 @@ impl AocClient {
         ))
         .unwrap();
 
+        let all_stars = if main.contains("calendar calendar-perfect") {
+            true
+        } else {
+            false
+        };
+
         // Remove stars that have not been collected
         let calendar = cleaned_up
             .lines()
@@ -394,13 +400,14 @@ impl AocClient {
                     .map(|c| c.as_str())
                     .unwrap_or("");
 
-                let stars = if class.contains("calendar-verycomplete") {
-                    "**"
-                } else if class.contains("calendar-complete") {
-                    "*"
-                } else {
-                    ""
-                };
+                let stars =
+                    if class.contains("calendar-verycomplete") || all_stars {
+                        "**"
+                    } else if class.contains("calendar-complete") {
+                        "*"
+                    } else {
+                        ""
+                    };
 
                 star_regex.replace(line, stars)
             })

--- a/aoc-client/src/lib.rs
+++ b/aoc-client/src/lib.rs
@@ -384,11 +384,7 @@ impl AocClient {
         ))
         .unwrap();
 
-        let all_stars = if main.contains("calendar calendar-perfect") {
-            true
-        } else {
-            false
-        };
+        let all_stars = main.contains("calendar calendar-perfect");
 
         // Remove stars that have not been collected
         let calendar = cleaned_up


### PR DESCRIPTION
Thanks so much for this tool! I noticed that when running the ``calendar`` option for 2022, the stars for Day 25 weren't showing up.  From what I can tell something in the regex gets messed up when the html for the balloon animations get added. 
I tried fixing this by adding a check for the string "calendar calendar-prefect" within the HTML (as this should only show up when the calendar is completed, and thus when the balloon animations get added). If this string is found, all days receive 2 stars ("**").

Before: 
![image](https://github.com/scarvalhojr/aoc-cli/assets/87077023/da6891d2-bb72-4c9d-b9b3-cf6c81cc60c7)
After:
![image](https://github.com/scarvalhojr/aoc-cli/assets/87077023/10c7c4ed-4ff5-46d4-8c5d-29f298a21202)

I've only fully completed 2022 (and partially 2021), so I'm not able to check if this bug applies to other years. I tested as much as I could, but apologies if I missed something!