### PR TITLE
feat: Global leaderboard

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -87,6 +87,10 @@ pub enum Command {
     #[command(visible_alias = "d")]
     Download,
 
+    /// Show Advent of Code global leaderboard
+    #[command(visible_alias = "g")]
+    GlobalLeaderboard,
+
     /// Read puzzle statement (the default command)
     #[command(visible_alias = "r")]
     Read,

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,7 @@ fn run(args: &Args, client: AocClient) -> AocResult<()> {
             }
             Ok(())
         }
+        Some(Command::GlobalLeaderboard) => client.show_global_leaderboard(),
         Some(Command::Submit { part, answer }) => {
             client.submit_answer_and_show_outcome(part, answer)
         }


### PR DESCRIPTION
As suggested in ``CONTRIBUTING.md``, this feature adds the ability to display the Global Leaderboard for a given year.

I've tested this on all years and it appears to be functioning correctly, but I'm happy to refactor/ fix things if they're not up to standard :)

Screenshot of (the start of) 2022:
![image](https://github.com/scarvalhojr/aoc-cli/assets/87077023/2dff9309-82fd-41a1-ae03-174cebed1fbb)
