### PR TITLE
feat: Personal stats

### DIFF
--- a/aoc-client/src/lib.rs
+++ b/aoc-client/src/lib.rs
@@ -384,6 +384,12 @@ impl AocClient {
         ))
         .unwrap();
 
+        let all_stars = if main.contains("calendar calendar-perfect") {
+            true
+        } else {
+            false
+        };
+
         // Remove stars that have not been collected
         let calendar = cleaned_up
             .lines()
@@ -394,13 +400,14 @@ impl AocClient {
                     .map(|c| c.as_str())
                     .unwrap_or("");
 
-                let stars = if class.contains("calendar-verycomplete") {
-                    "**"
-                } else if class.contains("calendar-complete") {
-                    "*"
-                } else {
-                    ""
-                };
+                let stars =
+                    if class.contains("calendar-verycomplete") || all_stars {
+                        "**"
+                    } else if class.contains("calendar-complete") {
+                        "*"
+                    } else {
+                        ""
+                    };
 
                 star_regex.replace(line, stars)
             })

--- a/aoc-client/src/lib.rs
+++ b/aoc-client/src/lib.rs
@@ -424,6 +424,52 @@ impl AocClient {
         Ok(())
     }
 
+    fn get_personal_stats_html(&self) -> AocResult<String> {
+        // TODO: Redirect means we're not logged in
+        debug!("🦌 Fetching {} personal stats", self.year);
+
+        let url =
+            format!("https://adventofcode.com/{}/leaderboard/self", self.year);
+        let response = http_client(&self.session_cookie, "text/html")?
+            .get(url)
+            .send()?;
+
+        if response.status() == StatusCode::NOT_FOUND {
+            // A 402 reponse means the calendar for
+            // the requested year is not yet available
+            return Err(AocError::InvalidEventYear(self.year));
+        } else if response.status() == StatusCode::FOUND {
+            // A 302 reponse is a redirect and it likely
+            // means we're not logged in
+            warn!(
+                "🍪 It looks like you are not logged in, try logging in again"
+            );
+            return Err(AocError::AocResponseError);
+        }
+
+        let contents = response.error_for_status()?.text()?;
+
+        let main = Regex::new(r"(?i)(?s)<main>(?P<main>.*)</main>")
+            .unwrap()
+            .captures(&contents)
+            .ok_or(AocError::AocResponseError)?
+            .name("main")
+            .unwrap()
+            .as_str()
+            .to_string();
+
+        Ok(main)
+    }
+
+    pub fn show_personal_stats(&self) -> AocResult<()> {
+        let stats_html = self.get_personal_stats_html()?;
+
+        let stats_text = self.html2text(&stats_html);
+        println!("{}", stats_text);
+
+        Ok(())
+    }
+
     fn get_private_leaderboard(
         &self,
         leaderboard_id: LeaderboardId,

--- a/aoc-client/src/lib.rs
+++ b/aoc-client/src/lib.rs
@@ -422,7 +422,6 @@ impl AocClient {
     }
 
     fn get_personal_stats_html(&self) -> AocResult<String> {
-        // TODO: Redirect means we're not logged in
         debug!("🦌 Fetching {} personal stats", self.year);
 
         let url =
@@ -460,9 +459,34 @@ impl AocClient {
 
     pub fn show_personal_stats(&self) -> AocResult<()> {
         let stats_html = self.get_personal_stats_html()?;
-
         let stats_text = self.html2text(&stats_html);
-        println!("{}", stats_text);
+
+        // print explanatory paragraph before recoloring the text
+        for line in stats_text.lines().take_while(|line| !line.is_empty()) {
+            println!("{}", line);
+        }
+
+        let stats_text = stats_text
+            .replace(
+                "--------Part 1---------",
+                &"--------Part 1---------".color(SILVER).to_string(),
+            )
+            .replace(
+                "--------Part 2---------",
+                &"--------Part 2---------".color(GOLD).to_string(),
+            )
+            .replace("Time", &"Time".color(GOLD).to_string())
+            .replace("Rank", &"Rank".color(GOLD).to_string())
+            .replace("Score", &"Score".color(GOLD).to_string())
+            .replacen("Time", &"Time".color(SILVER).to_string(), 1)
+            .replacen("Rank", &"Rank".color(SILVER).to_string(), 2) // "Rank" also in explanation
+            .replacen("Score", &"Score".color(SILVER).to_string(), 2); // "Score" also in
+                                                                       // explanation
+
+        // just print out the day by day stats, expalanatory paragraph is recolored now
+        for line in stats_text.lines().skip_while(|line| !line.is_empty()) {
+            println!("{}", line);
+        }
 
         Ok(())
     }

--- a/aoc-client/src/lib.rs
+++ b/aoc-client/src/lib.rs
@@ -425,7 +425,6 @@ impl AocClient {
     }
 
     fn get_personal_stats_html(&self) -> AocResult<String> {
-        // TODO: Redirect means we're not logged in
         debug!("🦌 Fetching {} personal stats", self.year);
 
         let url =
@@ -463,9 +462,34 @@ impl AocClient {
 
     pub fn show_personal_stats(&self) -> AocResult<()> {
         let stats_html = self.get_personal_stats_html()?;
-
         let stats_text = self.html2text(&stats_html);
-        println!("{}", stats_text);
+
+        // print explanatory paragraph before recoloring the text
+        for line in stats_text.lines().take_while(|line| !line.is_empty()) {
+            println!("{}", line);
+        }
+
+        let stats_text = stats_text
+            .replace(
+                "--------Part 1---------",
+                &"--------Part 1---------".color(SILVER).to_string(),
+            )
+            .replace(
+                "--------Part 2---------",
+                &"--------Part 2---------".color(GOLD).to_string(),
+            )
+            .replace("Time", &"Time".color(GOLD).to_string())
+            .replace("Rank", &"Rank".color(GOLD).to_string())
+            .replace("Score", &"Score".color(GOLD).to_string())
+            .replacen("Time", &"Time".color(SILVER).to_string(), 1)
+            .replacen("Rank", &"Rank".color(SILVER).to_string(), 2) // "Rank" also in explanation
+            .replacen("Score", &"Score".color(SILVER).to_string(), 2); // "Score" also in
+                                                                       // explanation
+
+        // just print out the day by day stats, expalanatory paragraph is recolored now
+        for line in stats_text.lines().skip_while(|line| !line.is_empty()) {
+            println!("{}", line);
+        }
 
         Ok(())
     }

--- a/aoc-client/src/lib.rs
+++ b/aoc-client/src/lib.rs
@@ -384,11 +384,7 @@ impl AocClient {
         ))
         .unwrap();
 
-        let all_stars = if main.contains("calendar calendar-perfect") {
-            true
-        } else {
-            false
-        };
+        let all_stars = main.contains("calendar calendar-perfect");
 
         // Remove stars that have not been collected
         let calendar = cleaned_up

--- a/src/args.rs
+++ b/src/args.rs
@@ -108,4 +108,8 @@ pub enum Command {
         /// Private leaderboard ID
         leaderboard_id: LeaderboardId,
     },
+
+    /// Show personal stats
+    #[command(visible_alias = "pe")]
+    PersonalStats,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ fn main() {
                 AocError::SessionFileNotFound => NO_INPUT,
                 AocError::SessionFileReadError { .. } => IO_ERROR,
                 AocError::InvalidSessionCookie { .. } => DATA_ERROR,
+                AocError::NotLoggedIn => DATA_ERROR,
                 AocError::HttpRequestError { .. } => FAILURE,
                 AocError::AocResponseError => FAILURE,
                 AocError::PrivateLeaderboardNotAvailable => FAILURE,

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,7 @@ fn run(args: &Args, client: AocClient) -> AocResult<()> {
             }
             Ok(())
         }
+        Some(Command::PersonalStats) => client.show_personal_stats(),
         Some(Command::Submit { part, answer }) => {
             client.submit_answer_and_show_outcome(part, answer)
         }


### PR DESCRIPTION
As suggested in ``CONTRIBUTING.md``, this feature adds the ability to display a user's personal stats for a given year.

While testing, I noticed that if you try to access personal stats while not logged in, the site redirects to show the global stats. I currently have ``show_personal_stats()`` return an ``AocError::AocResponseError`` in this case, but I wasn't super sure if that correctly describes what's happening. Any suggestions for a different error to return when this happens? 