### PR TITLE
fix: Calendar output

### DIFF
--- a/aoc-client/src/lib.rs
+++ b/aoc-client/src/lib.rs
@@ -384,28 +384,28 @@ impl AocClient {
         ))
         .unwrap();
 
-        let all_stars = main.contains("calendar calendar-perfect");
-
         // Remove stars that have not been collected
+        let mut star_state = "";
+
         let calendar = cleaned_up
             .lines()
             .map(|line| {
                 let class = class_regex
                     .captures(line)
                     .and_then(|c| c.name("class"))
-                    .map(|c| c.as_str())
-                    .unwrap_or("");
+                    .map(|c| c.as_str());
 
-                let stars =
-                    if class.contains("calendar-verycomplete") || all_stars {
+                if let Some(class) = class {
+                    star_state = if class.contains("calendar-verycomplete") {
                         "**"
                     } else if class.contains("calendar-complete") {
                         "*"
                     } else {
                         ""
                     };
+                }
 
-                star_regex.replace(line, stars)
+                star_regex.replace(line, star_state)
             })
             .collect::<Vec<_>>()
             .join("\n");

--- a/aoc-client/src/lib.rs
+++ b/aoc-client/src/lib.rs
@@ -368,9 +368,10 @@ impl AocClient {
             // Remove 2019 shadows
             r#"|(<span style="color[^>]*position:absolute"#,
             r#"[^>]*>\.</span>)"#,
-            // Remove 2019 "sunbeam"
-            r#"|(<span class="sunbeam"[^>]*>"#,
-            r#"<span style="animation-delay[^>]*>\*</span></span>)"#,
+            // Remove 2019 and 2023 animations
+            r#"|(<span [^>]*>"#,
+            r#"(<span [^>]*style="[^>]*animation-delay[^>]*>[^>]*</span>)+"#,
+            r#"</span>)"#,
         ))
         .unwrap()
         .replace_all(&main, "")


### PR DESCRIPTION
This pull request brings two following calendar output fixes.

## 1. Multiline task star output

Year 2023 and year 2022 used to omit the stars gained for the day on the top, since it is displayed in several lines:

```
                     ...'''''''''...                    
                  .'' ~/\* ~~~~  /\ ''.            14
```

It was fixed with `let all_stars = main.contains("calendar calendar-perfect");` for year 2022, however it does not actually work, since it displays incorrectly if the calendar is not perfect.

## 2. Year 2023 animations

The regex that removes 2019 animation was rewritten to remove all animations covering the 1 animation in year 2019 and 3 animations in year 2023.