### PR TITLE
feat: add flag for reading specified puzzle part

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -89,7 +89,11 @@ pub enum Command {
 
     /// Read puzzle statement (the default command)
     #[command(visible_alias = "r")]
-    Read,
+    Read {
+        /// Puzzle part
+        #[arg(long, value_parser = ["1", "2"])]
+        part: Option<String>,
+    },
 
     /// Submit puzzle answer
     #[command(visible_alias = "s")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,7 @@ fn run(args: &Args, client: AocClient) -> AocResult<()> {
         Some(Command::PrivateLeaderboard { leaderboard_id }) => {
             client.show_private_leaderboard(*leaderboard_id)
         }
-        _ => client.show_puzzle(),
+        Some(Command::Read { part }) => client.show_puzzle(part.as_deref()),
+        _ => client.show_puzzle(None),
     }
 }


### PR DESCRIPTION
Add an optional `--part` flag that accepts values `1` or `2` in the `read` subcommand for displaying/reading the specified part of the puzzle. If the flag is not specified, this defaults to displaying the entire puzzle.

This also adds some display consistencies. When output includes part 1 puzzle, the `--- Part One ---` subheader is included in the output. Additionally, if only displaying part 2 puzzle, the `--- Day Foo: Bar ---` header is included in the output.

Fixes: #27